### PR TITLE
the default value of ScaleBinned$n.breaks should be 4, not 5.

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -961,7 +961,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
           breaks <- self$trans$breaks(limits)
         }
       } else {
-        n.breaks <- self$n.breaks %||% 5 # same default as trans objects
+        n.breaks <- self$n.breaks %||% 4 # same default as trans objects
         breaks <- seq(limits[1], limits[2], length.out = n.breaks + 2)
         breaks <- breaks[-c(1, length(breaks))]
       }


### PR DESCRIPTION
The default value of ScaleBinned$n.breaks was set to the same as trans objects.
The default value of trans objects can map data to 5 colours in plot and legend, which is a direct-viewing color display.

However, when n.breaks is set to 5, ScaleBinned will map the data to 6 colours!
This occur in the codes:
https://github.com/tidyverse/ggplot2/blob/115c3960d0fd068f1ca4cfe4650c0e0474aabba5/R/scale-.r#L914
and
https://github.com/tidyverse/ggplot2/blob/115c3960d0fd068f1ca4cfe4650c0e0474aabba5/R/scale-.r#L928

So I think the default value of ScaleBinned$n.breaks should be 4, not 5, then it can works the same way as trans objects.